### PR TITLE
Add Strict mode option

### DIFF
--- a/src/Mailjet/Connection/Curl.php
+++ b/src/Mailjet/Connection/Curl.php
@@ -11,6 +11,9 @@ use Mailjet\Exception\Exception as ConnectionException;
  */
 class Curl extends HttpConnection
 {
+    private $strictCode     = array(0, 200, 201, 204);
+    private $permissiveCode = array(304);
+
     /**
      * Execute a cURL request to Mailjet API
      *
@@ -44,7 +47,12 @@ class Curl extends HttpConnection
 
         curl_close($ch);
 
-        if (!in_array($responseCode, array(0, 200, 201, 204))) {
+        $acceptedCode = ($this->options['strict'])
+            ? $this->strictCode
+            : array_merge($this->strictCode, $this->permissiveCode)
+        ;
+
+        if (!in_array($responseCode, $acceptedCode)) {
             throw new ConnectionException(null, (int)$responseCode);
         }
 
@@ -52,6 +60,6 @@ class Curl extends HttpConnection
             throw new ConnectionException($curlErrorMessage, (int)$curlErrorNumber);
         }
 
-        return $response;
+        return array('response' => $response, 'code' => $responseCode);
     }
 }

--- a/src/Mailjet/Connection/HttpConnection.php
+++ b/src/Mailjet/Connection/HttpConnection.php
@@ -13,10 +13,11 @@ abstract class HttpConnection implements ConnectionInterface
     protected $secretKey;
 
     protected $options = array(
-        'url' => ':protocol://api.mailjet.com/:version/:path',
+        'url'      => ':protocol://api.mailjet.com/:version/:path',
         'protocol' => 'http',
-        'version' => 0.1,
-        'output' => 'json',
+        'version'  => 0.1,
+        'output'   => 'json',
+        'strict'   => true
     );
 
     /**
@@ -27,7 +28,7 @@ abstract class HttpConnection implements ConnectionInterface
      */
     public function __construct($apiKey, $secretKey)
     {
-        $this->apiKey = $apiKey;
+        $this->apiKey    = $apiKey;
         $this->secretKey = $secretKey;
     }
 
@@ -88,9 +89,11 @@ abstract class HttpConnection implements ConnectionInterface
         $queryParams = array('output' => $this->options['output']);
         $queryParams = array_merge($params, $queryParams);
 
-        $encodedResponse = $this->request($url, $queryParams, $method);
+        $response = $this->request($url, $queryParams, $method);
+        $encodedResponse = $response['response'];
 
         $decodedResponse = $this->decodeResponse($encodedResponse, $this->options['output']);
+        $decodedResponse['code'] = $response['code'];
 
         return $decodedResponse;
     }
@@ -116,5 +119,8 @@ abstract class HttpConnection implements ConnectionInterface
         }
     }
 
+    /**
+     * @return array with response and response code keys
+     */
     abstract protected function request($url, array $params = array(), $method = 'GET');
 }


### PR DESCRIPTION
I suggest to add stric mode management option for connection. The pricipe of current version is to throw an exception when Response status code is 304. 
I think we could want to have a non-strict mode where no Exeption was throw. 

An use case is when you manage a subscription list, and someone already registred, ask for new subscription. The Mailjet API, will send a 304 code.

What is your opinion ?
